### PR TITLE
Be more relaxed about JSON input and more friendly in JSON output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ dist
 site
 mothertongues/ui
 venv
+*~

--- a/mothertongues/cli.py
+++ b/mothertongues/cli.py
@@ -116,7 +116,7 @@ def schema(
     """
     schema = get_schemas(type)
     with open(output, "w", encoding="utf8") as f:
-        json.dump(schema, f)
+        json.dump(schema, f, indent=4)
     return schema
 
 
@@ -139,9 +139,9 @@ def update_schemas():
     #         "type": "string"
     #     }
     with open(SCHEMA_DIR / "manifest.json", "w", encoding="utf8") as f:
-        json.dump(manifest_schema, f)
+        json.dump(manifest_schema, f, indent=4)
     with open(SCHEMA_DIR / "config.json", "w", encoding="utf8") as f:
-        json.dump(config_schema, f)
+        json.dump(config_schema, f, indent=4)
 
 
 @app.command()
@@ -187,7 +187,7 @@ def export(
         f"Writing dictionary data file to {(output_directory / 'dictionary_data.json')}"
     )
     with open(output_directory / "dictionary_data.json", "w", encoding="utf8") as f:
-        json.dump(output.model_dump(mode="json"), f)
+        json.dump(output.model_dump(mode="json"), f, indent=4)
 
 
 @app.command()

--- a/mothertongues/cli.py
+++ b/mothertongues/cli.py
@@ -56,6 +56,7 @@ def run(
         "WARNING: This is a Development server and is not secure for production"
     )
     httpd = socketserver.TCPServer(("", port), Handler)
+    logger.info("Open http://localhost:{port} in your browser to see your dictionary", port=port)
     try:
         httpd.serve_forever()
     except KeyboardInterrupt:
@@ -84,11 +85,12 @@ def build_and_run(
     output = dictionary.export()
     Handler = partial(SimpleHTTPRequestHandler, directory=UI_DIR)
     with open(UI_DIR / "assets" / "dictionary_data.json", "w", encoding="utf8") as f:
-        json.dump(output.model_dump(mode="json"), f)
+        json.dump(output.model_dump(mode="json"), f, indent=4)
     logger.warning(
         "WARNING: This is a Development server and is not secure for production"
     )
     httpd = socketserver.TCPServer(("", port), Handler)
+    logger.info("Open http://localhost:{port} in your browser to see your dictionary", port=port)
     try:
         httpd.serve_forever()
     except KeyboardInterrupt:

--- a/mothertongues/cli.py
+++ b/mothertongues/cli.py
@@ -56,7 +56,9 @@ def run(
         "WARNING: This is a Development server and is not secure for production"
     )
     httpd = socketserver.TCPServer(("", port), Handler)
-    logger.info("Open http://localhost:{port} in your browser to see your dictionary", port=port)
+    logger.info(
+        "Open http://localhost:{port} in your browser to see your dictionary", port=port
+    )
     try:
         httpd.serve_forever()
     except KeyboardInterrupt:
@@ -90,7 +92,9 @@ def build_and_run(
         "WARNING: This is a Development server and is not secure for production"
     )
     httpd = socketserver.TCPServer(("", port), Handler)
-    logger.info("Open http://localhost:{port} in your browser to see your dictionary", port=port)
+    logger.info(
+        "Open http://localhost:{port} in your browser to see your dictionary", port=port
+    )
     try:
         httpd.serve_forever()
     except KeyboardInterrupt:

--- a/mothertongues/config/models.py
+++ b/mothertongues/config/models.py
@@ -32,7 +32,8 @@ class BaseConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class Audio(BaseConfig, extra="allow"):
+class Audio(BaseConfig):
+    model_config = ConfigDict(extra="allow")
     description: Optional[str] = None
     """The location of the description of the audio (including speaker)"""
 
@@ -271,11 +272,12 @@ class ParserTargets(BaseConfig):
     #     return v
 
 
-class DictionaryEntry(BaseModel, extra="allow"):
+class DictionaryEntry(BaseModel):
     """There is a DictionaryEntry created for each entry in your dictionary.
     It intentionally shares the same data structure as the ParserTargets,
     but allows for extra fields.
     """
+    model_config = ConfigDict(extra="allow")
 
     word: str
     """The words in your dictionary"""
@@ -318,7 +320,6 @@ class DictionaryEntry(BaseModel, extra="allow"):
 
     source: Optional[str] = ""
     """The source of the entry"""
-    model_config = ConfigDict(extra="allow")
 
     @model_validator(mode="after")
     def entryID_to_str(self) -> "DictionaryEntry":
@@ -327,13 +328,14 @@ class DictionaryEntry(BaseModel, extra="allow"):
         return self
 
 
-class DictionaryEntryExportFormat(BaseModel, extra="allow"):
+class DictionaryEntryExportFormat(BaseModel):
     """There is a DictionaryEntry created for each entry in your dictionary.
     It intentionally shares the same data structure as the ParserTargets,
     but allows for extra fields. This is the same as DictionaryEntry except with
     some specifications for the output format (for example every exported entry will have)
     a value for entryID, and a sorting_form).
     """
+    model_config = ConfigDict(extra="allow")
 
     word: str
     """The words in your dictionary"""

--- a/mothertongues/config/models.py
+++ b/mothertongues/config/models.py
@@ -307,10 +307,10 @@ class DictionaryEntry(BaseModel, extra="allow"):
     example_sentence_definition: Optional[List[str]] = []
     """The example sentence definitions associated with the entry"""
 
-    example_sentence_audio: Optional[List[Audio|List[Audio]]] = []
+    example_sentence_audio: Optional[List[Union[Audio, List[Audio]]]] = []
     """The audio associated with the example sentences of the entry."""
 
-    example_sentence_definition_audio: Optional[List[Audio | List[Audio]]] = []
+    example_sentence_definition_audio: Optional[List[Union[Audio, List[Audio]]]] = []
     """The audio associated with the example sentence definitions of the entry."""
 
     optional: Optional[Dict[str, str]] = {}
@@ -368,10 +368,10 @@ class DictionaryEntryExportFormat(BaseModel, extra="allow"):
     example_sentence_definition: Optional[List[str]] = []
     """The example sentence definitions associated with the entry"""
 
-    example_sentence_audio: Optional[List[Audio|List[Audio]]] = []
+    example_sentence_audio: Optional[List[Union[Audio, List[Audio]]]] = []
     """The audio associated with the example sentences of the entry."""
 
-    example_sentence_definition_audio: Optional[List[Audio|List[Audio]]] = []
+    example_sentence_definition_audio: Optional[List[Union[Audio, List[Audio]]]] = []
     """The audio associated with the example sentence definitions of the entry."""
 
     optional: Optional[Dict[str, str]] = {}

--- a/mothertongues/config/models.py
+++ b/mothertongues/config/models.py
@@ -32,7 +32,7 @@ class BaseConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class Audio(BaseConfig):
+class Audio(BaseConfig, extra="allow"):
     description: Optional[str] = None
     """The location of the description of the audio (including speaker)"""
 
@@ -271,7 +271,7 @@ class ParserTargets(BaseConfig):
     #     return v
 
 
-class DictionaryEntry(BaseModel):
+class DictionaryEntry(BaseModel, extra="allow"):
     """There is a DictionaryEntry created for each entry in your dictionary.
     It intentionally shares the same data structure as the ParserTargets,
     but allows for extra fields.
@@ -307,10 +307,10 @@ class DictionaryEntry(BaseModel):
     example_sentence_definition: Optional[List[str]] = []
     """The example sentence definitions associated with the entry"""
 
-    example_sentence_audio: Optional[List[Audio]] = []
+    example_sentence_audio: Optional[List[Audio|List[Audio]]] = []
     """The audio associated with the example sentences of the entry."""
 
-    example_sentence_definition_audio: Optional[List[Audio]] = []
+    example_sentence_definition_audio: Optional[List[Audio | List[Audio]]] = []
     """The audio associated with the example sentence definitions of the entry."""
 
     optional: Optional[Dict[str, str]] = {}
@@ -327,7 +327,7 @@ class DictionaryEntry(BaseModel):
         return self
 
 
-class DictionaryEntryExportFormat(BaseModel):
+class DictionaryEntryExportFormat(BaseModel, extra="allow"):
     """There is a DictionaryEntry created for each entry in your dictionary.
     It intentionally shares the same data structure as the ParserTargets,
     but allows for extra fields. This is the same as DictionaryEntry except with
@@ -368,10 +368,10 @@ class DictionaryEntryExportFormat(BaseModel):
     example_sentence_definition: Optional[List[str]] = []
     """The example sentence definitions associated with the entry"""
 
-    example_sentence_audio: Optional[List[Audio]] = []
+    example_sentence_audio: Optional[List[Audio|List[Audio]]] = []
     """The audio associated with the example sentences of the entry."""
 
-    example_sentence_definition_audio: Optional[List[Audio]] = []
+    example_sentence_definition_audio: Optional[List[Audio|List[Audio]]] = []
     """The audio associated with the example sentence definitions of the entry."""
 
     optional: Optional[Dict[str, str]] = {}

--- a/mothertongues/config/models.py
+++ b/mothertongues/config/models.py
@@ -277,6 +277,7 @@ class DictionaryEntry(BaseModel):
     It intentionally shares the same data structure as the ParserTargets,
     but allows for extra fields.
     """
+
     model_config = ConfigDict(extra="allow")
 
     word: str
@@ -335,6 +336,7 @@ class DictionaryEntryExportFormat(BaseModel):
     some specifications for the output format (for example every exported entry will have)
     a value for entryID, and a sorting_form).
     """
+
     model_config = ConfigDict(extra="allow")
 
     word: str

--- a/mothertongues/config/models.py
+++ b/mothertongues/config/models.py
@@ -239,22 +239,25 @@ class ParserTargets(BaseConfig):
     audio: Optional[Union[List[Audio], Dict]] = None
     """The location of the audio associated with the entry."""
 
+    # Dict is used in case of json listof parser syntax
     definition_audio: Optional[Union[List[Audio], Dict]] = None
     """The location of the audio associated with the definition of the entry."""
 
+    # Dict is used in case of json listof parser syntax
     example_sentence: Optional[Union[List[str], Dict]] = None
     """The location(s) of any example sentences associated with the entry"""
 
+    # Dict is used in case of json listof parser syntax
     example_sentence_definition: Optional[Union[List[str], Dict]] = None
     """The location(s) of any example sentence definitions associated with the entry"""
 
-    example_sentence_audio: Optional[
-        Union[List[Union[Audio, List[Audio]]], Dict]
-    ] = None
+    # Dict is used in case of json listof parser syntax
+    example_sentence_audio: Optional[Union[List[Union[List[Audio], Dict]], Dict]] = None
     """The location of the audio associated with the example sentences of the entry."""
 
+    # Dict is used in case of json listof parser syntax
     example_sentence_definition_audio: Optional[
-        Union[List[Union[Audio, List[Audio]]], Dict]
+        Union[List[Union[List[Audio], Dict]], Dict]
     ] = None
     """The location of the audio associated with the example sentence definitions of the entry."""
 
@@ -314,10 +317,10 @@ class DictionaryEntry(BaseModel):
     example_sentence_definition: Optional[List[str]] = []
     """The example sentence definitions associated with the entry"""
 
-    example_sentence_audio: Optional[List[Union[Audio, List[Audio]]]] = []
+    example_sentence_audio: Optional[List[List[Audio]]] = []
     """The audio associated with the example sentences of the entry."""
 
-    example_sentence_definition_audio: Optional[List[Union[Audio, List[Audio]]]] = []
+    example_sentence_definition_audio: Optional[List[List[Audio]]] = []
     """The audio associated with the example sentence definitions of the entry."""
 
     optional: Optional[Dict[str, str]] = {}
@@ -376,10 +379,10 @@ class DictionaryEntryExportFormat(BaseModel):
     example_sentence_definition: Optional[List[str]] = []
     """The example sentence definitions associated with the entry"""
 
-    example_sentence_audio: Optional[List[Union[Audio, List[Audio]]]] = []
+    example_sentence_audio: Optional[List[List[Audio]]] = []
     """The audio associated with the example sentences of the entry."""
 
-    example_sentence_definition_audio: Optional[List[Union[Audio, List[Audio]]]] = []
+    example_sentence_definition_audio: Optional[List[List[Audio]]] = []
     """The audio associated with the example sentence definitions of the entry."""
 
     optional: Optional[Dict[str, str]] = {}

--- a/mothertongues/config/models.py
+++ b/mothertongues/config/models.py
@@ -248,10 +248,14 @@ class ParserTargets(BaseConfig):
     example_sentence_definition: Optional[Union[List[str], Dict]] = None
     """The location(s) of any example sentence definitions associated with the entry"""
 
-    example_sentence_audio: Optional[Union[List[Audio], Dict]] = None
+    example_sentence_audio: Optional[
+        Union[List[Union[Audio, List[Audio]]], Dict]
+    ] = None
     """The location of the audio associated with the example sentences of the entry."""
 
-    example_sentence_definition_audio: Optional[Union[List[Audio], Dict]] = None
+    example_sentence_definition_audio: Optional[
+        Union[List[Union[Audio, List[Audio]]], Dict]
+    ] = None
     """The location of the audio associated with the example sentence definitions of the entry."""
 
     optional: Optional[Dict[str, str]] = None

--- a/mothertongues/dictionary.py
+++ b/mothertongues/dictionary.py
@@ -92,7 +92,12 @@ class MTDictionary:
                 if not isinstance(entry, DictionaryEntry):
                     try:
                         entry = DictionaryEntry(**entry)
-                    except ValidationError:
+                    except ValidationError as err:
+                        logger.debug(
+                            "Failed to create DictionaryEntry from data {data}: {err}",
+                            data=entry,
+                            err=err,
+                        )
                         self.missing_data.append(
                             entry.get(
                                 CheckableParserTargetFieldNames.entryID.value,

--- a/mothertongues/dictionary.py
+++ b/mothertongues/dictionary.py
@@ -72,6 +72,7 @@ class MTDictionary:
             self.config.data = [self.config.data]
         # Process all data sources
         for i, data_source in enumerate(self.config.data):
+            logger.debug("Parsing data source {resource}", resource=data_source.resource)
             if data_source.manifest.file_type == ParserEnum.none:
                 data = data_source.resource
             else:
@@ -81,6 +82,7 @@ class MTDictionary:
                     logger.debug(
                         f"Tried parsing {data_source.resource} but there were {len(unparsable)} unparsable entries."
                     )
+            logger.debug("Found {n} entries", n=len(data))
             # create new list so that we only append valid
             # DictionaryEntry objects
             initialized_data = []

--- a/mothertongues/dictionary.py
+++ b/mothertongues/dictionary.py
@@ -72,7 +72,9 @@ class MTDictionary:
             self.config.data = [self.config.data]
         # Process all data sources
         for i, data_source in enumerate(self.config.data):
-            logger.debug("Parsing data source {resource}", resource=data_source.resource)
+            logger.debug(
+                "Parsing data source {resource}", resource=data_source.resource
+            )
             if data_source.manifest.file_type == ParserEnum.none:
                 data = data_source.resource
             else:

--- a/mothertongues/parsers/__init__.py
+++ b/mothertongues/parsers/__init__.py
@@ -67,20 +67,19 @@ class BaseTabularParser:
             :param function convert_function: A function that takes an entry and a path and returns the "filled in" object
         """
         new_lemma = {}
-
         for k, v in entry_template.items():
             if isinstance(v, dict):
                 new_lemma[k] = self.fill_entry_template(v, entry, convert_function)
             elif isinstance(v, list):
-                new_v = []
+                new_lemma[k] = []
                 for x in v:
-                    new_v += list(
-                        self.fill_entry_template(
-                            {k: x}, entry, convert_function
-                        ).values()
-                    )
-                # don't add items that only have empty values
-                new_lemma[k] = [x for x in new_v if any(x.values())]  # type: ignore
+                    values = self.fill_entry_template(
+                        {k: x}, entry, convert_function
+                    ).values()
+                    for y in values:
+                        # don't add dictionaries that only have empty values
+                        if not isinstance(y, dict) or any(y.values()):
+                            new_lemma[k].append(y)
             elif isinstance(v, str):
                 if v == "":
                     new_lemma[k] = ""  # type: ignore

--- a/mothertongues/parsers/__init__.py
+++ b/mothertongues/parsers/__init__.py
@@ -71,7 +71,7 @@ class BaseTabularParser:
             if isinstance(v, dict):
                 new_lemma[k] = self.fill_entry_template(v, entry, convert_function)
             elif isinstance(v, list):
-                new_lemma[k] = []
+                new_lemma[k] = []  # type: ignore
                 for x in v:
                     values = self.fill_entry_template(
                         {k: x}, entry, convert_function
@@ -80,7 +80,7 @@ class BaseTabularParser:
                         # don't add dictionaries that only have empty values
                         if isinstance(y, dict) and not any(y.values()):
                             continue
-                        new_lemma[k].append(y)
+                        new_lemma[k].append(y)  # type: ignore
             elif isinstance(v, str):
                 if v == "":
                     new_lemma[k] = ""  # type: ignore

--- a/mothertongues/parsers/__init__.py
+++ b/mothertongues/parsers/__init__.py
@@ -78,8 +78,9 @@ class BaseTabularParser:
                     ).values()
                     for y in values:
                         # don't add dictionaries that only have empty values
-                        if not isinstance(y, dict) or any(y.values()):
-                            new_lemma[k].append(y)
+                        if isinstance(y, dict) and not any(y.values()):
+                            continue
+                        new_lemma[k].append(y)
             elif isinstance(v, str):
                 if v == "":
                     new_lemma[k] = ""  # type: ignore

--- a/mothertongues/parsers/csv_parser.py
+++ b/mothertongues/parsers/csv_parser.py
@@ -12,4 +12,6 @@ class Parser(BaseTabularParser):
     def get_data(self):
         with open(self.resource_path, encoding="utf8") as f:
             reader = csv.reader(f, delimiter=",")
+            if self.manifest.skip_header:
+                _ = next(reader)
             return list(reader)

--- a/mothertongues/parsers/json_parser.py
+++ b/mothertongues/parsers/json_parser.py
@@ -38,8 +38,7 @@ class Parser(BaseTabularParser):
         if not path:
             return path
         jsonpath_expr = self.get_matcher(path)
-        result = jsonpath_expr.find(entry) or ""
-        return result
+        return jsonpath_expr.find(entry)
 
     def not_empty(self, value):
         if isinstance(value, dict):

--- a/mothertongues/parsers/json_parser.py
+++ b/mothertongues/parsers/json_parser.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List
 from jsonpath_ng import jsonpath
 from jsonpath_ng import parse as json_parse
 from jsonpointer import resolve_pointer
+from loguru import logger
 from tqdm import tqdm
 
 from mothertongues.config.models import DataSource

--- a/mothertongues/parsers/psv_parser.py
+++ b/mothertongues/parsers/psv_parser.py
@@ -12,4 +12,6 @@ class Parser(BaseTabularParser):
     def get_data(self):
         with open(self.resource_path, encoding="utf8") as f:
             reader = csv.reader(f, delimiter="|")
+            if self.manifest.skip_header:
+                _ = next(reader)
             return list(reader)

--- a/mothertongues/parsers/tsv_parser.py
+++ b/mothertongues/parsers/tsv_parser.py
@@ -12,4 +12,6 @@ class Parser(BaseTabularParser):
     def get_data(self):
         with open(self.resource_path, encoding="utf8") as f:
             reader = csv.reader(f, delimiter="\t")
+            if self.manifest.skip_header:
+                _ = next(reader)
             return list(reader)

--- a/mothertongues/schemas/config.json
+++ b/mothertongues/schemas/config.json
@@ -287,17 +287,10 @@
                     "anyOf": [
                         {
                             "items": {
-                                "anyOf": [
-                                    {
-                                        "$ref": "#/$defs/Audio"
-                                    },
-                                    {
-                                        "items": {
-                                            "$ref": "#/$defs/Audio"
-                                        },
-                                        "type": "array"
-                                    }
-                                ]
+                                "items": {
+                                    "$ref": "#/$defs/Audio"
+                                },
+                                "type": "array"
                             },
                             "type": "array"
                         },
@@ -312,17 +305,10 @@
                     "anyOf": [
                         {
                             "items": {
-                                "anyOf": [
-                                    {
-                                        "$ref": "#/$defs/Audio"
-                                    },
-                                    {
-                                        "items": {
-                                            "$ref": "#/$defs/Audio"
-                                        },
-                                        "type": "array"
-                                    }
-                                ]
+                                "items": {
+                                    "$ref": "#/$defs/Audio"
+                                },
+                                "type": "array"
                             },
                             "type": "array"
                         },
@@ -773,7 +759,17 @@
                     "anyOf": [
                         {
                             "items": {
-                                "$ref": "#/$defs/Audio"
+                                "anyOf": [
+                                    {
+                                        "items": {
+                                            "$ref": "#/$defs/Audio"
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "object"
+                                    }
+                                ]
                             },
                             "type": "array"
                         },
@@ -791,7 +787,17 @@
                     "anyOf": [
                         {
                             "items": {
-                                "$ref": "#/$defs/Audio"
+                                "anyOf": [
+                                    {
+                                        "items": {
+                                            "$ref": "#/$defs/Audio"
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "object"
+                                    }
+                                ]
                             },
                             "type": "array"
                         },

--- a/mothertongues/schemas/config.json
+++ b/mothertongues/schemas/config.json
@@ -1,1 +1,1073 @@
-{"title": "MTDConfiguration", "type": "object", "properties": {"config": {"$ref": "#/definitions/LanguageConfiguration"}, "data": {"title": "Data", "anyOf": [{"$ref": "#/definitions/DataSource"}, {"type": "array", "items": {"$ref": "#/definitions/DataSource"}}]}}, "required": ["config", "data"], "additionalProperties": false, "definitions": {"SearchAlgorithms": {"title": "SearchAlgorithms", "description": "An enumeration.", "enum": ["weighted_levenstein", "liblevenstein_automata"], "type": "string"}, "WeightedLevensteinConfig": {"title": "WeightedLevensteinConfig", "type": "object", "properties": {"insertionCost": {"title": "Insertioncost", "default": 1.0, "type": "number"}, "deletionCost": {"title": "Deletioncost", "default": 1.0, "type": "number"}, "insertionAtBeginningCost": {"title": "Insertionatbeginningcost", "default": 1.0, "type": "number"}, "deletionAtEndCost": {"title": "Deletionatendcost", "default": 1.0, "type": "number"}, "substitutionCosts": {"title": "Substitutioncosts", "default": {}, "type": "object", "additionalProperties": {"type": "object", "additionalProperties": {"type": "number"}}}, "substitutionCostsPath": {"title": "Substitutioncostspath", "format": "file-path", "type": "string"}, "defaultSubstitutionCost": {"title": "Defaultsubstitutioncost", "default": 1.0, "type": "number"}}, "additionalProperties": false}, "StemmerEnum": {"title": "StemmerEnum", "description": "An enumeration.", "enum": ["snowball_english", "none"], "type": "string"}, "NormalizationEnum": {"title": "NormalizationEnum", "description": "An enumeration.", "enum": ["NFC", "NFD", "NFKC", "NKFD", "none"], "type": "string"}, "RestrictedTransducer": {"title": "RestrictedTransducer", "type": "object", "properties": {"lower": {"title": "Lower", "default": true, "type": "boolean"}, "unicode_normalization": {"default": "NFC", "allOf": [{"$ref": "#/definitions/NormalizationEnum"}]}, "remove_punctuation": {"title": "Remove Punctuation", "default": "[.,/#!$%^&?*';:{}=\\-_`~()]", "type": "string"}, "remove_combining_characters": {"title": "Remove Combining Characters", "default": true, "type": "boolean"}, "replace_rules": {"title": "Replace Rules", "type": "object", "additionalProperties": {"type": "string"}}}, "additionalProperties": false}, "Contributor": {"title": "Contributor", "type": "object", "properties": {"role": {"title": "Role", "type": "string"}, "name": {"title": "Name", "type": "string"}}, "required": ["role", "name"], "additionalProperties": false}, "CheckableParserTargetFieldNames": {"title": "CheckableParserTargetFieldNames", "description": "An enumeration.", "enum": ["word", "definition", "entryID", "theme", "secondary_theme", "img", "audio", "definition_audio", "example_sentence", "example_sentence_definition", "example_sentence_audio", "example_sentence_definition_audio", "optional"]}, "LanguageConfiguration": {"title": "LanguageConfiguration", "type": "object", "properties": {"L1": {"title": "L1", "default": "YourLanguage", "type": "string"}, "L2": {"title": "L2", "default": "English", "type": "string"}, "l1_search_strategy": {"default": "weighted_levenstein", "allOf": [{"$ref": "#/definitions/SearchAlgorithms"}]}, "l2_search_strategy": {"default": "liblevenstein_automata", "allOf": [{"$ref": "#/definitions/SearchAlgorithms"}]}, "l1_search_config": {"$ref": "#/definitions/WeightedLevensteinConfig"}, "l2_search_config": {"$ref": "#/definitions/WeightedLevensteinConfig"}, "l1_stemmer": {"default": "none", "allOf": [{"$ref": "#/definitions/StemmerEnum"}]}, "l2_stemmer": {"default": "snowball_english", "allOf": [{"$ref": "#/definitions/StemmerEnum"}]}, "l1_normalization_transducer": {"$ref": "#/definitions/RestrictedTransducer"}, "l2_normalization_transducer": {"$ref": "#/definitions/RestrictedTransducer"}, "alphabet": {"title": "Alphabet", "default": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"], "anyOf": [{"type": "array", "items": {"type": "string"}}, {"type": "string", "format": "file-path"}]}, "optional_field_name": {"title": "Optional Field Name", "default": "Optional Field", "type": "string"}, "credits": {"title": "Credits", "type": "array", "items": {"$ref": "#/definitions/Contributor"}}, "build": {"title": "Build", "default": "mothertongues.utils.get_current_time", "type": "string"}, "no_sort_characters": {"title": "No Sort Characters", "default": [], "anyOf": [{"type": "array", "items": {"type": "string"}}, {"type": "string", "format": "file-path"}]}, "sorting_field": {"title": "Sorting Field", "default": "sort_form", "type": "string"}, "l1_keys_to_index": {"title": "L1 Keys To Index", "default": ["word"], "type": "array", "items": {"type": "string"}}, "l2_keys_to_index": {"title": "L2 Keys To Index", "default": ["definition"], "type": "array", "items": {"type": "string"}}, "duplicate_fields_subset": {"default": ["word", "entryID"], "type": "array", "items": {"$ref": "#/definitions/CheckableParserTargetFieldNames"}}, "required_fields": {"default": ["word", "definition"], "type": "array", "items": {"$ref": "#/definitions/CheckableParserTargetFieldNames"}}}, "additionalProperties": false}, "ParserEnum": {"title": "ParserEnum", "description": "An enumeration.", "enum": ["json", "csv", "psv", "tsv", "xlsx", "custom", "none"]}, "Transducer": {"title": "Transducer", "type": "object", "properties": {"input_field": {"title": "Input Field", "type": "string"}, "output_field": {"title": "Output Field", "type": "string"}}, "required": ["input_field", "output_field"], "additionalProperties": false}, "Audio": {"title": "Audio", "type": "object", "properties": {"description": {"title": "Description", "type": "string"}, "filename": {"title": "Filename", "type": "string"}}, "required": ["filename"], "additionalProperties": false}, "ParserTargets": {"title": "ParserTargets", "description": "Your ParserTargets define how to parse your data into a list of DictionaryEntry objects", "type": "object", "properties": {"word": {"title": "Word", "type": "string"}, "definition": {"title": "Definition", "type": "string"}, "entryID": {"title": "Entryid", "type": "string"}, "theme": {"title": "Theme", "type": "string"}, "secondary_theme": {"title": "Secondary Theme", "type": "string"}, "img": {"title": "Img", "type": "string"}, "source": {"title": "Source", "default": "", "type": "string"}, "audio": {"title": "Audio", "anyOf": [{"type": "array", "items": {"$ref": "#/definitions/Audio"}}, {"type": "object"}]}, "definition_audio": {"title": "Definition Audio", "anyOf": [{"type": "array", "items": {"$ref": "#/definitions/Audio"}}, {"type": "object"}]}, "example_sentence": {"title": "Example Sentence", "anyOf": [{"type": "array", "items": {"type": "string"}}, {"type": "object"}]}, "example_sentence_definition": {"title": "Example Sentence Definition", "anyOf": [{"type": "array", "items": {"type": "string"}}, {"type": "object"}]}, "example_sentence_audio": {"title": "Example Sentence Audio", "anyOf": [{"type": "array", "items": {"$ref": "#/definitions/Audio"}}, {"type": "object"}]}, "example_sentence_definition_audio": {"title": "Example Sentence Definition Audio", "anyOf": [{"type": "array", "items": {"$ref": "#/definitions/Audio"}}, {"type": "object"}]}, "optional": {"title": "Optional", "type": "object", "additionalProperties": {"type": "string"}}}, "required": ["word", "definition"], "additionalProperties": false}, "ResourceManifest": {"title": "ResourceManifest", "type": "object", "properties": {"file_type": {"default": "none", "allOf": [{"$ref": "#/definitions/ParserEnum"}]}, "name": {"title": "Name", "default": "YourData", "type": "string"}, "skip_header": {"title": "Skip Header", "default": false, "type": "boolean"}, "transducers": {"title": "Transducers", "default": [], "type": "array", "items": {"$ref": "#/definitions/Transducer"}}, "audio_path": {"title": "Audio Path", "minLength": 1, "maxLength": 2083, "format": "uri", "type": "string"}, "img_path": {"title": "Img Path", "minLength": 1, "maxLength": 2083, "format": "uri", "type": "string"}, "targets": {"$ref": "#/definitions/ParserTargets"}, "sheet_name": {"title": "Sheet Name", "type": "string"}, "json_parser_entrypoint": {"title": "Json Parser Entrypoint", "type": "string"}}, "additionalProperties": false}, "DictionaryEntry": {"title": "DictionaryEntry", "description": "There is a DictionaryEntry created for each entry in your dictionary.\nIt intentionally shares the same data structure as the ParserTargets,\nbut allows for extra fields.", "type": "object", "properties": {"word": {"title": "Word", "type": "string"}, "definition": {"title": "Definition", "type": "string"}, "entryID": {"title": "Entryid", "type": "string"}, "theme": {"title": "Theme", "default": "", "type": "string"}, "secondary_theme": {"title": "Secondary Theme", "default": "", "type": "string"}, "img": {"title": "Img", "default": "", "type": "string"}, "audio": {"title": "Audio", "default": [], "type": "array", "items": {"$ref": "#/definitions/Audio"}}, "definition_audio": {"title": "Definition Audio", "default": [], "type": "array", "items": {"$ref": "#/definitions/Audio"}}, "example_sentence": {"title": "Example Sentence", "default": [], "type": "array", "items": {"type": "string"}}, "example_sentence_definition": {"title": "Example Sentence Definition", "default": [], "type": "array", "items": {"type": "string"}}, "example_sentence_audio": {"title": "Example Sentence Audio", "default": [], "type": "array", "items": {"$ref": "#/definitions/Audio"}}, "example_sentence_definition_audio": {"title": "Example Sentence Definition Audio", "default": [], "type": "array", "items": {"$ref": "#/definitions/Audio"}}, "optional": {"title": "Optional", "default": {}, "type": "object", "additionalProperties": {"type": "string"}}, "source": {"title": "Source", "default": "", "type": "string"}}, "required": ["word", "definition"]}, "DataSource": {"title": "DataSource", "type": "object", "properties": {"manifest": {"$ref": "#/definitions/ResourceManifest"}, "resource": {"title": "Resource", "anyOf": [{"type": "string", "format": "file-path"}, {"type": "array", "items": {"type": "object"}}, {"type": "array", "items": {"$ref": "#/definitions/DictionaryEntry"}}]}}, "required": ["manifest", "resource"], "additionalProperties": false}}}
+{
+    "$defs": {
+        "ArbitraryFieldRestrictedTransducer": {
+            "additionalProperties": false,
+            "properties": {
+                "lower": {
+                    "default": true,
+                    "title": "Lower",
+                    "type": "boolean"
+                },
+                "unicode_normalization": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/NormalizationEnum"
+                        }
+                    ],
+                    "default": "NFC"
+                },
+                "remove_punctuation": {
+                    "default": "[.,/#!$%^&?*';:{}=\\-_`~()]",
+                    "title": "Remove Punctuation",
+                    "type": "string"
+                },
+                "remove_combining_characters": {
+                    "default": true,
+                    "title": "Remove Combining Characters",
+                    "type": "boolean"
+                },
+                "replace_rules": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Replace Rules"
+                },
+                "input_field": {
+                    "title": "Input Field",
+                    "type": "string"
+                },
+                "output_field": {
+                    "title": "Output Field",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "input_field",
+                "output_field"
+            ],
+            "title": "ArbitraryFieldRestrictedTransducer",
+            "type": "object"
+        },
+        "Audio": {
+            "additionalProperties": true,
+            "properties": {
+                "description": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Description"
+                },
+                "filename": {
+                    "title": "Filename",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "filename"
+            ],
+            "title": "Audio",
+            "type": "object"
+        },
+        "CheckableParserTargetFieldNames": {
+            "enum": [
+                "word",
+                "definition",
+                "entryID",
+                "theme",
+                "secondary_theme",
+                "img",
+                "audio",
+                "definition_audio",
+                "example_sentence",
+                "example_sentence_definition",
+                "example_sentence_audio",
+                "example_sentence_definition_audio",
+                "optional"
+            ],
+            "title": "CheckableParserTargetFieldNames",
+            "type": "string"
+        },
+        "Contributor": {
+            "additionalProperties": false,
+            "properties": {
+                "role": {
+                    "title": "Role",
+                    "type": "string"
+                },
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "role",
+                "name"
+            ],
+            "title": "Contributor",
+            "type": "object"
+        },
+        "DataSource": {
+            "additionalProperties": false,
+            "properties": {
+                "manifest": {
+                    "$ref": "#/$defs/ResourceManifest"
+                },
+                "resource": {
+                    "anyOf": [
+                        {
+                            "format": "file-path",
+                            "type": "string"
+                        },
+                        {
+                            "items": {
+                                "type": "object"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "items": {
+                                "$ref": "#/$defs/DictionaryEntry"
+                            },
+                            "type": "array"
+                        }
+                    ],
+                    "title": "Resource"
+                }
+            },
+            "required": [
+                "manifest",
+                "resource"
+            ],
+            "title": "DataSource",
+            "type": "object"
+        },
+        "DictionaryEntry": {
+            "additionalProperties": true,
+            "description": "There is a DictionaryEntry created for each entry in your dictionary.\nIt intentionally shares the same data structure as the ParserTargets,\nbut allows for extra fields.",
+            "properties": {
+                "word": {
+                    "title": "Word",
+                    "type": "string"
+                },
+                "definition": {
+                    "title": "Definition",
+                    "type": "string"
+                },
+                "entryID": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "format": "uuid",
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Entryid"
+                },
+                "theme": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": "",
+                    "title": "Theme"
+                },
+                "secondary_theme": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": "",
+                    "title": "Secondary Theme"
+                },
+                "img": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": "",
+                    "title": "Img"
+                },
+                "audio": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/Audio"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": [],
+                    "title": "Audio"
+                },
+                "definition_audio": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/Audio"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": [],
+                    "title": "Definition Audio"
+                },
+                "example_sentence": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": [],
+                    "title": "Example Sentence"
+                },
+                "example_sentence_definition": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": [],
+                    "title": "Example Sentence Definition"
+                },
+                "example_sentence_audio": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "$ref": "#/$defs/Audio"
+                                    },
+                                    {
+                                        "items": {
+                                            "$ref": "#/$defs/Audio"
+                                        },
+                                        "type": "array"
+                                    }
+                                ]
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": [],
+                    "title": "Example Sentence Audio"
+                },
+                "example_sentence_definition_audio": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "anyOf": [
+                                    {
+                                        "$ref": "#/$defs/Audio"
+                                    },
+                                    {
+                                        "items": {
+                                            "$ref": "#/$defs/Audio"
+                                        },
+                                        "type": "array"
+                                    }
+                                ]
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": [],
+                    "title": "Example Sentence Definition Audio"
+                },
+                "optional": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": {},
+                    "title": "Optional"
+                },
+                "source": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": "",
+                    "title": "Source"
+                }
+            },
+            "required": [
+                "word",
+                "definition"
+            ],
+            "title": "DictionaryEntry",
+            "type": "object"
+        },
+        "LanguageConfiguration": {
+            "additionalProperties": false,
+            "properties": {
+                "L1": {
+                    "default": "YourLanguage",
+                    "title": "L1",
+                    "type": "string"
+                },
+                "L2": {
+                    "default": "English",
+                    "title": "L2",
+                    "type": "string"
+                },
+                "l1_search_strategy": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/SearchAlgorithms"
+                        }
+                    ],
+                    "default": "weighted_levenstein"
+                },
+                "l2_search_strategy": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/SearchAlgorithms"
+                        }
+                    ],
+                    "default": "liblevenstein_automata"
+                },
+                "l1_search_config": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/WeightedLevensteinConfig"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "l2_search_config": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/WeightedLevensteinConfig"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "l1_stemmer": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/StemmerEnum"
+                        }
+                    ],
+                    "default": "none"
+                },
+                "l2_stemmer": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/StemmerEnum"
+                        }
+                    ],
+                    "default": "snowball_english"
+                },
+                "l1_normalization_transducer": {
+                    "$ref": "#/$defs/RestrictedTransducer"
+                },
+                "l2_normalization_transducer": {
+                    "$ref": "#/$defs/RestrictedTransducer"
+                },
+                "alphabet": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "format": "file-path",
+                            "type": "string"
+                        }
+                    ],
+                    "default": [
+                        "a",
+                        "b",
+                        "c",
+                        "d",
+                        "e",
+                        "f",
+                        "g",
+                        "h",
+                        "i",
+                        "j",
+                        "k",
+                        "l",
+                        "m",
+                        "n",
+                        "o",
+                        "p",
+                        "q",
+                        "r",
+                        "s",
+                        "t",
+                        "u",
+                        "v",
+                        "w",
+                        "x",
+                        "y",
+                        "z",
+                        "A",
+                        "B",
+                        "C",
+                        "D",
+                        "E",
+                        "F",
+                        "G",
+                        "H",
+                        "I",
+                        "J",
+                        "K",
+                        "L",
+                        "M",
+                        "N",
+                        "O",
+                        "P",
+                        "Q",
+                        "R",
+                        "S",
+                        "T",
+                        "U",
+                        "V",
+                        "W",
+                        "X",
+                        "Y",
+                        "Z"
+                    ],
+                    "title": "Alphabet"
+                },
+                "optional_field_name": {
+                    "default": "Optional Field",
+                    "title": "Optional Field Name",
+                    "type": "string"
+                },
+                "credits": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/Contributor"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Credits"
+                },
+                "build": {
+                    "default": "mothertongues.utils.get_current_time",
+                    "title": "Build",
+                    "type": "string"
+                },
+                "no_sort_characters": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "format": "file-path",
+                            "type": "string"
+                        }
+                    ],
+                    "default": [],
+                    "title": "No Sort Characters"
+                },
+                "sorting_field": {
+                    "default": "sort_form",
+                    "title": "Sorting Field",
+                    "type": "string"
+                },
+                "l1_keys_to_index": {
+                    "default": [
+                        "word"
+                    ],
+                    "items": {
+                        "type": "string"
+                    },
+                    "title": "L1 Keys To Index",
+                    "type": "array"
+                },
+                "l2_keys_to_index": {
+                    "default": [
+                        "definition"
+                    ],
+                    "items": {
+                        "type": "string"
+                    },
+                    "title": "L2 Keys To Index",
+                    "type": "array"
+                },
+                "duplicate_fields_subset": {
+                    "default": [
+                        "word",
+                        "entryID"
+                    ],
+                    "items": {
+                        "$ref": "#/$defs/CheckableParserTargetFieldNames"
+                    },
+                    "title": "Duplicate Fields Subset",
+                    "type": "array"
+                },
+                "required_fields": {
+                    "default": [
+                        "word",
+                        "definition"
+                    ],
+                    "items": {
+                        "$ref": "#/$defs/CheckableParserTargetFieldNames"
+                    },
+                    "title": "Required Fields",
+                    "type": "array"
+                }
+            },
+            "title": "LanguageConfiguration",
+            "type": "object"
+        },
+        "NormalizationEnum": {
+            "enum": [
+                "NFC",
+                "NFD",
+                "NFKC",
+                "NKFD",
+                "none"
+            ],
+            "title": "NormalizationEnum",
+            "type": "string"
+        },
+        "ParserEnum": {
+            "enum": [
+                "json",
+                "csv",
+                "psv",
+                "tsv",
+                "xlsx",
+                "custom",
+                "none"
+            ],
+            "title": "ParserEnum",
+            "type": "string"
+        },
+        "ParserTargets": {
+            "additionalProperties": false,
+            "description": "Your ParserTargets define how to parse your data into a list of DictionaryEntry objects",
+            "properties": {
+                "word": {
+                    "title": "Word",
+                    "type": "string"
+                },
+                "definition": {
+                    "title": "Definition",
+                    "type": "string"
+                },
+                "entryID": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Entryid"
+                },
+                "theme": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Theme"
+                },
+                "secondary_theme": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Secondary Theme"
+                },
+                "img": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Img"
+                },
+                "source": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": "",
+                    "title": "Source"
+                },
+                "audio": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/Audio"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Audio"
+                },
+                "definition_audio": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/Audio"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Definition Audio"
+                },
+                "example_sentence": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Example Sentence"
+                },
+                "example_sentence_definition": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Example Sentence Definition"
+                },
+                "example_sentence_audio": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/Audio"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Example Sentence Audio"
+                },
+                "example_sentence_definition_audio": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/Audio"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Example Sentence Definition Audio"
+                },
+                "optional": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Optional"
+                }
+            },
+            "required": [
+                "word",
+                "definition"
+            ],
+            "title": "ParserTargets",
+            "type": "object"
+        },
+        "ResourceManifest": {
+            "additionalProperties": false,
+            "properties": {
+                "file_type": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/ParserEnum"
+                        }
+                    ],
+                    "default": "none"
+                },
+                "name": {
+                    "default": "YourData",
+                    "title": "Name",
+                    "type": "string"
+                },
+                "skip_header": {
+                    "default": false,
+                    "title": "Skip Header",
+                    "type": "boolean"
+                },
+                "transducers": {
+                    "default": [],
+                    "items": {
+                        "$ref": "#/$defs/ArbitraryFieldRestrictedTransducer"
+                    },
+                    "title": "Transducers",
+                    "type": "array"
+                },
+                "audio_path": {
+                    "anyOf": [
+                        {
+                            "format": "uri",
+                            "maxLength": 2083,
+                            "minLength": 1,
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Audio Path"
+                },
+                "img_path": {
+                    "anyOf": [
+                        {
+                            "format": "uri",
+                            "maxLength": 2083,
+                            "minLength": 1,
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Img Path"
+                },
+                "targets": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/$defs/ParserTargets"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null
+                },
+                "sheet_name": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Sheet Name"
+                },
+                "json_parser_entrypoint": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Json Parser Entrypoint"
+                }
+            },
+            "title": "ResourceManifest",
+            "type": "object"
+        },
+        "RestrictedTransducer": {
+            "additionalProperties": false,
+            "properties": {
+                "lower": {
+                    "default": true,
+                    "title": "Lower",
+                    "type": "boolean"
+                },
+                "unicode_normalization": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/NormalizationEnum"
+                        }
+                    ],
+                    "default": "NFC"
+                },
+                "remove_punctuation": {
+                    "default": "[.,/#!$%^&?*';:{}=\\-_`~()]",
+                    "title": "Remove Punctuation",
+                    "type": "string"
+                },
+                "remove_combining_characters": {
+                    "default": true,
+                    "title": "Remove Combining Characters",
+                    "type": "boolean"
+                },
+                "replace_rules": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Replace Rules"
+                }
+            },
+            "title": "RestrictedTransducer",
+            "type": "object"
+        },
+        "SearchAlgorithms": {
+            "enum": [
+                "weighted_levenstein",
+                "liblevenstein_automata"
+            ],
+            "title": "SearchAlgorithms",
+            "type": "string"
+        },
+        "StemmerEnum": {
+            "enum": [
+                "snowball_english",
+                "none"
+            ],
+            "title": "StemmerEnum",
+            "type": "string"
+        },
+        "WeightedLevensteinConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "insertionCost": {
+                    "default": 1.0,
+                    "title": "Insertioncost",
+                    "type": "number"
+                },
+                "deletionCost": {
+                    "default": 1.0,
+                    "title": "Deletioncost",
+                    "type": "number"
+                },
+                "insertionAtBeginningCost": {
+                    "default": 1.0,
+                    "title": "Insertionatbeginningcost",
+                    "type": "number"
+                },
+                "deletionAtEndCost": {
+                    "default": 1.0,
+                    "title": "Deletionatendcost",
+                    "type": "number"
+                },
+                "substitutionCosts": {
+                    "additionalProperties": {
+                        "additionalProperties": {
+                            "type": "number"
+                        },
+                        "type": "object"
+                    },
+                    "default": {},
+                    "title": "Substitutioncosts",
+                    "type": "object"
+                },
+                "substitutionCostsPath": {
+                    "anyOf": [
+                        {
+                            "format": "file-path",
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Substitutioncostspath"
+                },
+                "defaultSubstitutionCost": {
+                    "default": 1.0,
+                    "title": "Defaultsubstitutioncost",
+                    "type": "number"
+                }
+            },
+            "title": "WeightedLevensteinConfig",
+            "type": "object"
+        }
+    },
+    "additionalProperties": false,
+    "properties": {
+        "config": {
+            "$ref": "#/$defs/LanguageConfiguration"
+        },
+        "data": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/DataSource"
+                },
+                {
+                    "items": {
+                        "$ref": "#/$defs/DataSource"
+                    },
+                    "type": "array"
+                }
+            ],
+            "title": "Data"
+        }
+    },
+    "required": [
+        "config",
+        "data"
+    ],
+    "title": "MTDConfiguration",
+    "type": "object"
+}

--- a/mothertongues/schemas/manifest.json
+++ b/mothertongues/schemas/manifest.json
@@ -1,1 +1,410 @@
-{"title": "ResourceManifest", "type": "object", "properties": {"file_type": {"default": "none", "allOf": [{"$ref": "#/definitions/ParserEnum"}]}, "name": {"title": "Name", "default": "YourData", "type": "string"}, "skip_header": {"title": "Skip Header", "default": false, "type": "boolean"}, "transducers": {"title": "Transducers", "default": [], "type": "array", "items": {"$ref": "#/definitions/Transducer"}}, "audio_path": {"title": "Audio Path", "minLength": 1, "maxLength": 2083, "format": "uri", "type": "string"}, "img_path": {"title": "Img Path", "minLength": 1, "maxLength": 2083, "format": "uri", "type": "string"}, "targets": {"$ref": "#/definitions/ParserTargets"}, "sheet_name": {"title": "Sheet Name", "type": "string"}, "json_parser_entrypoint": {"title": "Json Parser Entrypoint", "type": "string"}}, "additionalProperties": false, "definitions": {"ParserEnum": {"title": "ParserEnum", "description": "An enumeration.", "enum": ["json", "csv", "psv", "tsv", "xlsx", "custom", "none"]}, "Transducer": {"title": "Transducer", "type": "object", "properties": {"input_field": {"title": "Input Field", "type": "string"}, "output_field": {"title": "Output Field", "type": "string"}}, "required": ["input_field", "output_field"], "additionalProperties": false}, "Audio": {"title": "Audio", "type": "object", "properties": {"description": {"title": "Description", "type": "string"}, "filename": {"title": "Filename", "type": "string"}}, "required": ["filename"], "additionalProperties": false}, "ParserTargets": {"title": "ParserTargets", "description": "Your ParserTargets define how to parse your data into a list of DictionaryEntry objects", "type": "object", "properties": {"word": {"title": "Word", "type": "string"}, "definition": {"title": "Definition", "type": "string"}, "entryID": {"title": "Entryid", "type": "string"}, "theme": {"title": "Theme", "type": "string"}, "secondary_theme": {"title": "Secondary Theme", "type": "string"}, "img": {"title": "Img", "type": "string"}, "source": {"title": "Source", "default": "", "type": "string"}, "audio": {"title": "Audio", "anyOf": [{"type": "array", "items": {"$ref": "#/definitions/Audio"}}, {"type": "object"}]}, "definition_audio": {"title": "Definition Audio", "anyOf": [{"type": "array", "items": {"$ref": "#/definitions/Audio"}}, {"type": "object"}]}, "example_sentence": {"title": "Example Sentence", "anyOf": [{"type": "array", "items": {"type": "string"}}, {"type": "object"}]}, "example_sentence_definition": {"title": "Example Sentence Definition", "anyOf": [{"type": "array", "items": {"type": "string"}}, {"type": "object"}]}, "example_sentence_audio": {"title": "Example Sentence Audio", "anyOf": [{"type": "array", "items": {"$ref": "#/definitions/Audio"}}, {"type": "object"}]}, "example_sentence_definition_audio": {"title": "Example Sentence Definition Audio", "anyOf": [{"type": "array", "items": {"$ref": "#/definitions/Audio"}}, {"type": "object"}]}, "optional": {"title": "Optional", "type": "object", "additionalProperties": {"type": "string"}}}, "required": ["word", "definition"], "additionalProperties": false}}}
+{
+    "$defs": {
+        "ArbitraryFieldRestrictedTransducer": {
+            "additionalProperties": false,
+            "properties": {
+                "lower": {
+                    "default": true,
+                    "title": "Lower",
+                    "type": "boolean"
+                },
+                "unicode_normalization": {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/NormalizationEnum"
+                        }
+                    ],
+                    "default": "NFC"
+                },
+                "remove_punctuation": {
+                    "default": "[.,/#!$%^&?*';:{}=\\-_`~()]",
+                    "title": "Remove Punctuation",
+                    "type": "string"
+                },
+                "remove_combining_characters": {
+                    "default": true,
+                    "title": "Remove Combining Characters",
+                    "type": "boolean"
+                },
+                "replace_rules": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Replace Rules"
+                },
+                "input_field": {
+                    "title": "Input Field",
+                    "type": "string"
+                },
+                "output_field": {
+                    "title": "Output Field",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "input_field",
+                "output_field"
+            ],
+            "title": "ArbitraryFieldRestrictedTransducer",
+            "type": "object"
+        },
+        "Audio": {
+            "additionalProperties": true,
+            "properties": {
+                "description": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Description"
+                },
+                "filename": {
+                    "title": "Filename",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "filename"
+            ],
+            "title": "Audio",
+            "type": "object"
+        },
+        "NormalizationEnum": {
+            "enum": [
+                "NFC",
+                "NFD",
+                "NFKC",
+                "NKFD",
+                "none"
+            ],
+            "title": "NormalizationEnum",
+            "type": "string"
+        },
+        "ParserEnum": {
+            "enum": [
+                "json",
+                "csv",
+                "psv",
+                "tsv",
+                "xlsx",
+                "custom",
+                "none"
+            ],
+            "title": "ParserEnum",
+            "type": "string"
+        },
+        "ParserTargets": {
+            "additionalProperties": false,
+            "description": "Your ParserTargets define how to parse your data into a list of DictionaryEntry objects",
+            "properties": {
+                "word": {
+                    "title": "Word",
+                    "type": "string"
+                },
+                "definition": {
+                    "title": "Definition",
+                    "type": "string"
+                },
+                "entryID": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Entryid"
+                },
+                "theme": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Theme"
+                },
+                "secondary_theme": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Secondary Theme"
+                },
+                "img": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Img"
+                },
+                "source": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": "",
+                    "title": "Source"
+                },
+                "audio": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/Audio"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Audio"
+                },
+                "definition_audio": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/Audio"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Definition Audio"
+                },
+                "example_sentence": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Example Sentence"
+                },
+                "example_sentence_definition": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Example Sentence Definition"
+                },
+                "example_sentence_audio": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/Audio"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Example Sentence Audio"
+                },
+                "example_sentence_definition_audio": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "$ref": "#/$defs/Audio"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Example Sentence Definition Audio"
+                },
+                "optional": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Optional"
+                }
+            },
+            "required": [
+                "word",
+                "definition"
+            ],
+            "title": "ParserTargets",
+            "type": "object"
+        }
+    },
+    "additionalProperties": false,
+    "properties": {
+        "file_type": {
+            "allOf": [
+                {
+                    "$ref": "#/$defs/ParserEnum"
+                }
+            ],
+            "default": "none"
+        },
+        "name": {
+            "default": "YourData",
+            "title": "Name",
+            "type": "string"
+        },
+        "skip_header": {
+            "default": false,
+            "title": "Skip Header",
+            "type": "boolean"
+        },
+        "transducers": {
+            "default": [],
+            "items": {
+                "$ref": "#/$defs/ArbitraryFieldRestrictedTransducer"
+            },
+            "title": "Transducers",
+            "type": "array"
+        },
+        "audio_path": {
+            "anyOf": [
+                {
+                    "format": "uri",
+                    "maxLength": 2083,
+                    "minLength": 1,
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "default": null,
+            "title": "Audio Path"
+        },
+        "img_path": {
+            "anyOf": [
+                {
+                    "format": "uri",
+                    "maxLength": 2083,
+                    "minLength": 1,
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "default": null,
+            "title": "Img Path"
+        },
+        "targets": {
+            "anyOf": [
+                {
+                    "$ref": "#/$defs/ParserTargets"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "default": null
+        },
+        "sheet_name": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "default": null,
+            "title": "Sheet Name"
+        },
+        "json_parser_entrypoint": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "default": null,
+            "title": "Json Parser Entrypoint"
+        }
+    },
+    "title": "ResourceManifest",
+    "type": "object"
+}

--- a/mothertongues/schemas/manifest.json
+++ b/mothertongues/schemas/manifest.json
@@ -255,7 +255,17 @@
                     "anyOf": [
                         {
                             "items": {
-                                "$ref": "#/$defs/Audio"
+                                "anyOf": [
+                                    {
+                                        "items": {
+                                            "$ref": "#/$defs/Audio"
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "object"
+                                    }
+                                ]
                             },
                             "type": "array"
                         },
@@ -273,7 +283,17 @@
                     "anyOf": [
                         {
                             "items": {
-                                "$ref": "#/$defs/Audio"
+                                "anyOf": [
+                                    {
+                                        "items": {
+                                            "$ref": "#/$defs/Audio"
+                                        },
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "object"
+                                    }
+                                ]
                             },
                             "type": "array"
                         },

--- a/mothertongues/tests/data/config_csv_multi.json
+++ b/mothertongues/tests/data/config_csv_multi.json
@@ -1,0 +1,13 @@
+{
+    "config": {
+        "L1": "Danish",
+        "L2": "English",
+        "build": "mothertongues.utils.get_current_time",
+        "optional_field_name": "Optional Info",
+        "alphabet": "./alphabet.json"
+    },
+    "data": [{
+        "manifest": "./manifest_csv_multi.json",
+        "resource": "./data_multi.csv"
+    }]
+}

--- a/mothertongues/tests/data/data_invalid.json
+++ b/mothertongues/tests/data/data_invalid.json
@@ -1,0 +1,4 @@
+[{
+  "definition": "tree",
+  "word": 42
+}]

--- a/mothertongues/tests/data/data_multi.csv
+++ b/mothertongues/tests/data/data_multi.csv
@@ -1,0 +1,2 @@
+entryID,definition,word,audio1_description,audio1_filename,theme,pos,example_sentence1,example_definition1,example1_audio1_description,example1_audio1_filename,example1_audio2_description,example1_audio2_filename
+1,tree,træ,Aidan Pine,tree.mp3,plants,noun,Har du røde øjne?,Do you have red eyes?,Aidan Pine,rode1.mp3,Aidan Pine,rode2.mp3

--- a/mothertongues/tests/data/manifest_csv_multi.json
+++ b/mothertongues/tests/data/manifest_csv_multi.json
@@ -1,0 +1,37 @@
+{
+    "file_type": "csv",
+    "skip_header": true,
+    "name": "words",
+    "transducers": [{
+        "input_field": "word",
+        "output_field": "sort_form",
+        "lower": true
+    }],
+    "targets": {
+        "entryID": "0",
+        "definition": "1",
+        "word": "2",
+        "audio": [{
+            "description": "3",
+            "filename": "4"
+        }],
+        "theme": "5",
+        "optional": {
+            "Part of Speech": "6"
+        },
+        "example_sentence": ["7"],
+        "example_sentence_definition": ["8"],
+        "example_sentence_audio": [
+            [
+                {
+                    "description": "9",
+                    "filename": "10"
+                },
+                {
+                    "description": "11",
+                    "filename": "12"
+                }
+            ]
+        ]
+    }
+}

--- a/mothertongues/tests/data/manifest_json.json
+++ b/mothertongues/tests/data/manifest_json.json
@@ -17,10 +17,17 @@
                 "filename": "filename"
             }
         },
-        "example_sentence": [
-            "example_sentence_1",
-            "example_sentence_2"
-        ],
+        "example_sentence": ["example_sentence_1", "example_sentence_2"],
+        "example_sentence_audio": {
+            "listof": "example_sentence_audio",
+            "value": {
+                "listof": "$",
+                "value": {
+                    "description": "speaker",
+                    "filename": "filename"
+                }
+            }
+        },
         "example_sentence_definition": [
             "example_sentence_definition_1",
             "example_sentence_definition_2"

--- a/mothertongues/tests/test_cli.py
+++ b/mothertongues/tests/test_cli.py
@@ -10,7 +10,7 @@ from mothertongues.config.models import (
     MTDExportFormat,
 )
 from mothertongues.tests.base_test_case import BasicTestCase
-from mothertongues.utils import capture_logs
+from mothertongues.tests.utils import capture_logs
 
 
 class CommandLineTest(BasicTestCase):

--- a/mothertongues/tests/test_dictionary_data.py
+++ b/mothertongues/tests/test_dictionary_data.py
@@ -1,14 +1,28 @@
+from contextlib import contextmanager
 from copy import deepcopy
+from loguru import logger
 
 from mothertongues.config.models import (
     CheckableParserTargetFieldNames,
     LanguageConfiguration,
     MTDConfiguration,
     ResourceManifest,
+    ParserEnum,
+    ParserTargets,
 )
 from mothertongues.dictionary import DataSource, MTDictionary
 from mothertongues.tests.base_test_case import BasicTestCase
 from mothertongues.utils import load_mtd_configuration
+
+
+# See https://loguru.readthedocs.io/en/latest/resources/migration.html#replacing-assertlogs-method-from-unittest-library
+@contextmanager
+def capture_logs(level="INFO", format="{level}:{name}:{message}"):
+    """Capture loguru-based logs."""
+    output = []
+    handler_id = logger.add(output.append, level=level, format=format)
+    yield output
+    logger.remove(handler_id)
 
 
 class DictionaryDataTest(BasicTestCase):
@@ -16,16 +30,44 @@ class DictionaryDataTest(BasicTestCase):
 
     def setUp(self):
         super().setUp()
-        language_config_path = self.data_dir / "config_data_check.json"
-        config = load_mtd_configuration(language_config_path)
-        self.mtd_config = MTDConfiguration(**config)
-        self.dictionary = MTDictionary(self.mtd_config)
 
     def test_no_data(self):
         empty_data = DataSource(manifest=ResourceManifest(), resource=[])
         config = MTDConfiguration(config=LanguageConfiguration(), data=empty_data)
         dictionary = MTDictionary(config)
         self.assertEqual(len(dictionary), 0)
+
+    def test_validation_error(self):
+        bad_data = DataSource(
+            manifest=ResourceManifest(),
+            resource=[{"word": "foo", "definition": 42}]
+        )
+        config = MTDConfiguration(
+            config=LanguageConfiguration(sorting_field="word"), data=bad_data
+        )
+        with capture_logs("DEBUG") as logs:
+            dictionary = MTDictionary(config)
+            self.assertEqual(len(dictionary), 0)
+        self.assertIn("validation error", "".join(logs))
+
+    def test_validation_error_json(self):
+        bad_data = DataSource(
+            manifest=ResourceManifest(
+                file_type=ParserEnum.json,
+                targets=ParserTargets(
+                    word="word",
+                    definition="definition",
+                ),
+            ),
+            resource=self.data_dir / "data_invalid.json",
+        )
+        config = MTDConfiguration(
+            config=LanguageConfiguration(sorting_field="word"), data=bad_data
+        )
+        with capture_logs("DEBUG") as logs:
+            dictionary = MTDictionary(config)
+            self.assertEqual(len(dictionary), 0)
+        self.assertIn("validation error", "".join(logs))
 
     def test_missing_definitions(self):
         empty_data = DataSource(
@@ -62,13 +104,22 @@ class DictionaryDataTest(BasicTestCase):
         # The second entry from the second data source (entry override of source label 'test3')
         self.assertEqual(dictionary.data[2]["entryID"], "test311")
 
+    def read_data_check(self):
+        language_config_path = self.data_dir / "config_data_check.json"
+        config = load_mtd_configuration(language_config_path)
+        self.mtd_config = MTDConfiguration(**config)
+        self.dictionary = MTDictionary(self.mtd_config)
+
     def test_missing_chars(self):
+        self.read_data_check()
         self.assertIn("😀", self.dictionary.sorter.oovs)
 
     def test_duplicates(self):
+        self.read_data_check()
         self.assertCountEqual(self.dictionary.duplicates, ["4", "6", "9"])
 
     def test_info(self):
+        self.read_data_check()
         self.assertEqual(self.dictionary[0]["entryID"], "5")
 
     def test_minimal(self):
@@ -79,6 +130,7 @@ class DictionaryDataTest(BasicTestCase):
         self.assertEqual(dictionary.data[0]["entryID"], "words00")
 
     def test_missing_required_fields(self):
+        self.read_data_check()
         self.assertCountEqual(["7", "6", "9"], self.dictionary.missing_data)
         looser_config = deepcopy(self.mtd_config)
         looser_config.config.required_fields = [CheckableParserTargetFieldNames.theme]

--- a/mothertongues/tests/test_dictionary_data.py
+++ b/mothertongues/tests/test_dictionary_data.py
@@ -1,14 +1,15 @@
 from contextlib import contextmanager
 from copy import deepcopy
+
 from loguru import logger
 
 from mothertongues.config.models import (
     CheckableParserTargetFieldNames,
     LanguageConfiguration,
     MTDConfiguration,
-    ResourceManifest,
     ParserEnum,
     ParserTargets,
+    ResourceManifest,
 )
 from mothertongues.dictionary import DataSource, MTDictionary
 from mothertongues.tests.base_test_case import BasicTestCase
@@ -39,8 +40,7 @@ class DictionaryDataTest(BasicTestCase):
 
     def test_validation_error(self):
         bad_data = DataSource(
-            manifest=ResourceManifest(),
-            resource=[{"word": "foo", "definition": 42}]
+            manifest=ResourceManifest(), resource=[{"word": "foo", "definition": 42}]
         )
         config = MTDConfiguration(
             config=LanguageConfiguration(sorting_field="word"), data=bad_data

--- a/mothertongues/tests/test_dictionary_data.py
+++ b/mothertongues/tests/test_dictionary_data.py
@@ -118,10 +118,38 @@ class DictionaryDataTest(BasicTestCase):
         self.assertEqual(dictionary.data[2]["entryID"], "test311")
 
     def test_multiple_example_audio(self):
-        language_config_path = self.data_dir / "config_csv_multi.json"
-        config = load_mtd_configuration(language_config_path)
-        mtd_config = MTDConfiguration(**config)
-        dictionary = MTDictionary(mtd_config)
+        dictionary = self.create_test_dictionary_from_config("config_csv_multi.json")
+        self.assertEqual(len(dictionary), 1)
+        entry = dictionary.data[0]
+        self.assertEqual(
+            entry,
+            {
+                "word": "træ",
+                "definition": "tree",
+                "entryID": "1",
+                "theme": "plants",
+                "secondary_theme": "",
+                "img": "",
+                "audio": [{"description": "Aidan Pine", "filename": "tree.mp3"}],
+                "definition_audio": [],
+                "example_sentence": ["Har du røde øjne?"],
+                "example_sentence_definition": ["Do you have red eyes?"],
+                "example_sentence_audio": [
+                    [
+                        {"description": "Aidan Pine", "filename": "rode1.mp3"},
+                        {"description": "Aidan Pine", "filename": "rode2.mp3"},
+                    ]
+                ],
+                "example_sentence_definition_audio": [],
+                "optional": {"Part of Speech": "noun"},
+                "source": "words",
+                "sort_form": "træ",
+                "sorting_form": [19, 17, 26],
+            },
+        )
+
+    def test_multiple_sentences(self):
+        dictionary = self.create_test_dictionary_from_config("config_csv_multi.json")
         self.assertEqual(len(dictionary), 1)
         entry = dictionary.data[0]
         self.assertEqual(
@@ -164,11 +192,14 @@ class DictionaryDataTest(BasicTestCase):
         self.assertEqual(self.dictionary[0]["entryID"], "5")
 
     def test_minimal(self):
-        config_path = self.data_dir / "config_minimal.json"
-        config = load_mtd_configuration(config_path)
-        mtd_config = MTDConfiguration(**config)
-        dictionary = MTDictionary(mtd_config)
+        dictionary = self.create_test_dictionary_from_config("config_minimal.json")
         self.assertEqual(dictionary.data[0]["entryID"], "words00")
+
+    def create_test_dictionary_from_config(self, config):
+        language_config_path = self.data_dir / config
+        config = load_mtd_configuration(language_config_path)
+        mtd_config = MTDConfiguration(**config)
+        return MTDictionary(mtd_config)
 
     def test_missing_required_fields(self):
         self.read_data_check()

--- a/mothertongues/tests/test_dictionary_data.py
+++ b/mothertongues/tests/test_dictionary_data.py
@@ -117,6 +117,40 @@ class DictionaryDataTest(BasicTestCase):
         # The second entry from the second data source (entry override of source label 'test3')
         self.assertEqual(dictionary.data[2]["entryID"], "test311")
 
+    def test_multiple_example_audio(self):
+        language_config_path = self.data_dir / "config_csv_multi.json"
+        config = load_mtd_configuration(language_config_path)
+        mtd_config = MTDConfiguration(**config)
+        dictionary = MTDictionary(mtd_config)
+        self.assertEqual(len(dictionary), 1)
+        entry = dictionary.data[0]
+        self.assertEqual(
+            entry,
+            {
+                "word": "træ",
+                "definition": "tree",
+                "entryID": "1",
+                "theme": "plants",
+                "secondary_theme": "",
+                "img": "",
+                "audio": [{"description": "Aidan Pine", "filename": "tree.mp3"}],
+                "definition_audio": [],
+                "example_sentence": ["Har du røde øjne?"],
+                "example_sentence_definition": ["Do you have red eyes?"],
+                "example_sentence_audio": [
+                    [
+                        {"description": "Aidan Pine", "filename": "rode1.mp3"},
+                        {"description": "Aidan Pine", "filename": "rode2.mp3"},
+                    ]
+                ],
+                "example_sentence_definition_audio": [],
+                "optional": {"Part of Speech": "noun"},
+                "source": "words",
+                "sort_form": "træ",
+                "sorting_form": [19, 17, 26],
+            },
+        )
+
     def test_missing_chars(self):
         self.read_data_check()
         self.assertIn("😀", self.dictionary.sorter.oovs)

--- a/mothertongues/tests/test_parsers.py
+++ b/mothertongues/tests/test_parsers.py
@@ -169,7 +169,16 @@ class DictionaryParserTest(BasicTestCase):
                     "Do you have red eyes?",
                     "Dead, red, red-eyed, rotten, smoked trout.",
                 ],
-                "example_sentence_audio": [],
+                "example_sentence_audio": [
+                    [
+                        {"description": "AP", "filename": "ap_sent1.mp3"},
+                        {"description": "AR", "filename": "ar_sent1.mp3"},
+                    ],
+                    [
+                        {"description": "AP", "filename": "ap_sent2.mp3"},
+                        {"description": "AR", "filename": "ar_sent2.mp3"},
+                    ],
+                ],
                 "example_sentence_definition_audio": [],
                 "optional": {"Part of Speech": "noun"},
                 "source": "words",
@@ -187,6 +196,9 @@ class DictionaryParserTest(BasicTestCase):
         self.maxDiff = None
         self.assertEqual(dictionary.data[0]["word"], "farvel")
         self.assertEqual(dictionary.data[3]["word"], "træ")
+        self.assertEqual(len(dictionary.data[3]["example_sentence"]), 2)
+        self.assertEqual(len(dictionary.data[3]["example_sentence_audio"]), 2)
+        self.assertEqual(len(dictionary.data[3]["example_sentence_audio"][0]), 2)
         self.assertCountEqual(dictionary.data, self.parsed_data)
 
     def test_basic_tabular_parsers(self):
@@ -270,6 +282,9 @@ class DictionaryParserTest(BasicTestCase):
         data[3]["example_sentence"] = self.parsed_data[3]["example_sentence"]
         data[3]["example_sentence_definition"] = self.parsed_data[3][
             "example_sentence_definition"
+        ]
+        data[3]["example_sentence_audio"] = self.parsed_data[3][
+            "example_sentence_audio"
         ]
         return data
 

--- a/mothertongues/tests/test_parsers.py
+++ b/mothertongues/tests/test_parsers.py
@@ -200,6 +200,9 @@ class DictionaryParserTest(BasicTestCase):
             self.assertEqual(dictionary.data[3]["word"], "træ")
             data = self._correct_data(dictionary.data)
             self.assertCountEqual(data, self.parsed_data)
+            mtd_config.data[0].manifest.skip_header = True
+            dictionary = MTDictionary(mtd_config)
+            self.assertEqual(len(dictionary.data), len(self.parsed_data) - 1)
 
     def test_xlsx_specifics(self):
         language_config_path = self.data_dir / "config_xlsx.json"

--- a/mothertongues/tests/utils.py
+++ b/mothertongues/tests/utils.py
@@ -1,0 +1,13 @@
+from contextlib import contextmanager
+
+from loguru import logger
+
+
+# See https://loguru.readthedocs.io/en/latest/resources/migration.html#replacing-assertlogs-method-from-unittest-library
+@contextmanager
+def capture_logs(level="INFO", format="{level}:{name}:{message}"):
+    """Capture loguru-based logs. Particularly useful for unit testing"""
+    output = []
+    handler_id = logger.add(output.append, level=level, format=format)
+    yield output
+    logger.remove(handler_id)

--- a/mothertongues/utils.py
+++ b/mothertongues/utils.py
@@ -184,12 +184,3 @@ def string_to_callable(string: Union[Callable, str]) -> Union[str, Callable]:
             f"Cannot find method '{function}' in module '{module}'"
         ) from exc
     return function
-
-
-@contextmanager
-def capture_logs(level="INFO", format="{level}:{name}:{message}"):
-    """Capture loguru-based logs. Particularly useful for unit testing"""
-    output = []
-    handler_id = logger.add(output.append, level=level, format=format)
-    yield output
-    logger.remove(handler_id)


### PR DESCRIPTION
The documentation already mentions that `DictionaryEntry` accepts extra fields, but this wasn't actually the case.

Also, `Audio` should accept extra fields (we use them for read-along in the Michif dictionary).

Also, example sentences should be allowed to have multiple audio clips (this is not supported by the default web UI but at least it should not cause a `ValidationError`)

Also `ValidationError` should be reported so it can be fixed.

Also the JSON output should be indented so humans can read it (it will probably get prettified or uglified anyway, whichever the case may be).

And finally the CLI should give you a URL in its output, not just in the help text.

Fixes #16  and #19 